### PR TITLE
Fix minor typo at Advisory::CVE_2020_9377

### DIFF
--- a/lib/Spellbook/Advisory/CVE_2020_9377.pm
+++ b/lib/Spellbook/Advisory/CVE_2020_9377.pm
@@ -44,7 +44,7 @@ package Spellbook::Advisory::CVE_2020_9377 {
                 \r=======================
                 \r-h, --help     See this menu
                 \r-t, --target   Define a target
-                \r-c, --cokie    Define a session cookie
+                \r-c, --cookie    Define a session cookie
                 \r-p, --payload  Set the command to run on the target\n\n";
         }
 


### PR DESCRIPTION
This commit fixes a minor typo in the Advisory::CVE_2020_9377 module where "cookie" was misspelled as "cokie" in the help message